### PR TITLE
add QUARKUS_EXTENSIONS_DIR local dir

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,18 +1,19 @@
-# Docker compose
-POSTGRES_DB=
-POSTGRES_USER=
-POSTGRES_PASSWORD=
-PORT=8080
-# needed to increase Github API rate limit
-GITHUB_ID=
-GITHUB_SECRET=
+
 
 # keycloak build
 STACK=scalingo-20
 JQ_VERSION=1.6
 JRE_MAJOR_VERSION=11
-# KEYCLOAK_VERSION=latest
-KEYCLOAK_PROVIDERS=tchapgouv/tchap-identite
+KEYCLOAK_VERSION=18.0.1
+# KEYCLOAK_PROVIDERS=tchapgouv/tchap-identite
+
+
+# Docker compose (test)
+POSTGRES_DB=
+POSTGRES_USER=
+POSTGRES_PASSWORD=
+PORT=8080
+
 KEYCLOAK_ADMIN=
 KEYCLOAK_ADMIN_PASSWORD=
 # keycloak run envs

--- a/bin/compile
+++ b/bin/compile
@@ -79,6 +79,18 @@ if [[ -f "${ENV_DIR}/KEYCLOAK_LOCAL_PROVIDER_DIR" ]]; then
   fi
 fi
 
+step "Adding extensions from quarkus extensions directory"
+if [[ -f "${ENV_DIR}/QUARKUS_EXTENSIONS_DIR" ]]; then
+  QUARKUS_EXTENSIONS_DIR=$(cat "${ENV_DIR}/QUARKUS_EXTENSIONS_DIR")
+  if [[ -d "${BUILD_DIR}/${QUARKUS_EXTENSIONS_DIR}" ]]; then
+    jar_file=$(find "${BUILD_DIR}/${QUARKUS_EXTENSIONS_DIR}"/*.jar | head -n 1)
+    start "Installing jars ${jar_file}"
+    cp "${jar_file}" "${KEYCLOAK_PATH}/providers/"
+    finished
+  else
+        warn "Unable to found directory : ${BUILD_DIR}/${QUARKUS_EXTENSIONS_DIR}"
+  fi
+fi
 
 step "Adding templates"
 if [[ -f "${ENV_DIR}/KEYCLOAK_TEMPLATES_DIR" ]]; then

--- a/bin/compile
+++ b/bin/compile
@@ -83,10 +83,11 @@ step "Adding extensions from quarkus extensions directory"
 if [[ -f "${ENV_DIR}/QUARKUS_EXTENSIONS_DIR" ]]; then
   QUARKUS_EXTENSIONS_DIR=$(cat "${ENV_DIR}/QUARKUS_EXTENSIONS_DIR")
   if [[ -d "${BUILD_DIR}/${QUARKUS_EXTENSIONS_DIR}" ]]; then
-    jar_file=$(find "${BUILD_DIR}/${QUARKUS_EXTENSIONS_DIR}"/*.jar | head -n 1)
-    start "Installing jars ${jar_file}"
-    cp "${jar_file}" "${KEYCLOAK_PATH}/providers/"
-    finished
+    for jar_file in "${BUILD_DIR}/${QUARKUS_EXTENSIONS_DIR}"/*.jar; do
+      start "Installing extension ${jar_file}"
+      cp "${jar_file}" "${KEYCLOAK_PATH}/providers/"
+      finished
+    done
   else
         warn "Unable to found directory : ${BUILD_DIR}/${QUARKUS_EXTENSIONS_DIR}"
   fi


### PR DESCRIPTION
if variable QUARKUS_EXTENSIONS_DIR is set, all jars contained in the directory will be copied to /providers dir. 
It allows to install quarkus extensions.

Keycloak version is set to 18.0.1